### PR TITLE
feat: add add-version-label github action

### DIFF
--- a/.github/workflows/run-add-version-label.yml
+++ b/.github/workflows/run-add-version-label.yml
@@ -1,0 +1,11 @@
+name: ☢️ Add Version Label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  run-add-version-label:
+    uses: artsy/duchamp/.github/workflows/add-version-label.yml@main
+    secrets:
+      danger-token: ${{ secrets.DANGER_TOKEN }}


### PR DESCRIPTION
This PR adds a github action workflow to run adding a version label. The logic is exactly the same as what was run in peril. It supports the effort to retire peril in favor of github actions.