### PR TITLE
feat: add yarn check github action

### DIFF
--- a/.github/workflows/run-danger-yarn.yml
+++ b/.github/workflows/run-danger-yarn.yml
@@ -1,0 +1,11 @@
+name: ☢️ Danger - Yarn
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  run-danger-yarn:
+    uses: artsy/duchamp/.github/workflows/danger-yarn.yml@main
+    secrets:
+      danger-token: ${{ secrets.DANGER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docs for [Palette](https://github.com/artsy/palette), built on top of [Gatsby](h
 - Docs URL: [https://palette.artsy.net](https://palette.artsy.net)
 - Palette Github Repo: [https://github.com/artsy/palette](https://github.com/artsy/palette)
 - Storybook: [https://palette-storybook.artsy.net](https://palette-storybook.artsy.net)
-- Point People: [@damassi](https://github.com/damassi), [@dzucconi](https://github.com/dzucconi)
+- Point People: [@dzucconi](https://github.com/dzucconi)
 
 ### Development
 


### PR DESCRIPTION
This PR adds a github action workflow to run our yarn check. The logic is exactly the same as what was run in peril. It supports the effort to retire peril in favor of github actions.